### PR TITLE
開発標準の同期スクリプトを追加（Template + sync 方式へ移行）

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ npm run setup
 ```
 
 `npm run setup` は [CodeAppsDevelopmentStandard](https://github.com/geekfujiwara/CodeAppsDevelopmentStandard) から
-`.github/`（GeekPowerCode エージェント・スキル一式）と共有ファイル（`auth_helper.py` / `public/maps/` 等）を
-このプロジェクトに同期し、続けて環境チェック（bootstrap）を実行します。
+`.github/`（GeekPowerCode エージェント・スキル一式。認証ヘルパー・日本語パッチ・地図 SVG 等のスキル所有アセットを含む）と
+`scripts/`（共通ツール）・`.env.example` をこのプロジェクトに同期し、続けて環境チェック（bootstrap）を実行します。
 
 - 標準の更新を取り込むときは `npm run sync-standards` を再実行します（テーマ固有のコードには触れません）
 - リファレンス実装サンプルは同期されません（必要なら `node scripts/sync-standards.mjs --with-samples`）

--- a/README.md
+++ b/README.md
@@ -106,16 +106,29 @@ https://github.com/user-attachments/assets/d9cef0e8-91ca-41ea-b40f-5f342dd98a13
 
 ### インストール
 
-```PowerShell
-# リポジトリをクローン
-git clone https://github.com/geekfujiwara/CodeAppsStarter.git
-cd CodeAppsStarter
-```
+このリポジトリは **Template repository** です。clone ではなくテンプレートから自分のリポジトリを生成します。
 
 ```PowerShell
-# 依存関係をインストール
-npm install
+# テンプレートから新しいテーマのリポジトリを生成して clone（private 推奨）
+gh repo create <your-account>/<your-theme-repo> --template geekfujiwara/CodeAppsStarter --private --clone
+cd <your-theme-repo>
 ```
+
+> リモートを作らずローカルだけで試す場合: `npx degit geekfujiwara/CodeAppsStarter <フォルダ名>`
+
+```PowerShell
+# 依存関係をインストール + 開発標準（エージェント・スキル）を同期
+npm install
+npm run setup
+```
+
+`npm run setup` は [CodeAppsDevelopmentStandard](https://github.com/geekfujiwara/CodeAppsDevelopmentStandard) から
+`.github/`（GeekPowerCode エージェント・スキル一式）と共有ファイル（`auth_helper.py` / `public/maps/` 等）を
+このプロジェクトに同期し、続けて環境チェック（bootstrap）を実行します。
+
+- 標準の更新を取り込むときは `npm run sync-standards` を再実行します（テーマ固有のコードには触れません）
+- リファレンス実装サンプルは同期されません（必要なら `node scripts/sync-standards.mjs --with-samples`）
+- `.power/` / `src/generated/` / `power.config.json` は同期対象外です。**`pac code init` / `pac code add-data-source` で Power Apps SDK に生成させてください**
 
 ```PowerShell
 # 開発サーバーを起動

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "sync-standards": "node scripts/sync-standards.mjs",
-    "setup": "node scripts/sync-standards.mjs --setup"
+    "setup": "node scripts/sync-standards.mjs --setup",
+    "predeploy": "node scripts/pre-deploy-check.mjs",
+    "deploy": "npm run build && pac code push"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "sync-standards": "node scripts/sync-standards.mjs",
+    "setup": "node scripts/sync-standards.mjs --setup"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/sync-standards.mjs
+++ b/scripts/sync-standards.mjs
@@ -9,13 +9,15 @@
  *   node scripts/sync-standards.mjs --setup         # 同期後に bootstrap（環境チェック）も実行
  *   node scripts/sync-standards.mjs --with-samples  # サンプル実装（skills/＊/samples/）も取得
  *
- * 同期対象（標準リポ → このプロジェクト）:
- *   .github/                  … エージェント・スキル（template-root/ と samples/ は除外）
- *   .claude/                  … Claude Code エージェント定義（存在する場合）
- *   .github/template-root/*   … テーマのルートに展開される共有ファイル:
- *                                 auth_helper.py / patch-nameutils.cjs / .env.example /
- *                                 public/maps/ / scripts/（bootstrap.mjs・pre-deploy-check.mjs）
- *   work/input/               … spec-to-markdown の入力ディレクトリ（空で作成）
+ * 同期対象（標準リポ → このプロジェクト・同じ相対パスにコピー）:
+ *   .github/             … エージェント・スキル（samples/ は除外）
+ *   .claude/             … Claude Code エージェント定義（存在する場合）
+ *   auth_helper.py       … MSAL 認証ヘルパー
+ *   patch-nameutils.cjs  … 日本語 DisplayName パッチ
+ *   public/maps/         … japan-map 共有 SVG
+ *   scripts/bootstrap.mjs / scripts/pre-deploy-check.mjs … 標準スクリプト
+ *   .env.example         … 環境変数テンプレート（既存なら上書きしない）
+ *   work/input/          … spec-to-markdown の入力ディレクトリ（空で作成）
  *
  * 同期 *しない* もの:
  *   skills/＊/samples/（--with-samples 指定時を除く）
@@ -38,12 +40,20 @@ const runSetup = process.argv.includes("--setup");
 
 // skills/<name>/samples/ 配下を判定（--with-samples 指定がなければ除外）
 const SAMPLES_RE = /(^|[\\/])skills[\\/][^\\/]+[\\/]samples([\\/]|$)/;
-// .github 直下の template-root（テーマのルートへ別途展開するため .github コピーからは除外）
-const TEMPLATE_ROOT_RE = /(^|[\\/])template-root([\\/]|$)/;
 
 function copyTree(src, dest, { filter } = {}) {
   if (!fs.existsSync(src)) return false;
   fs.cpSync(src, dest, { recursive: true, force: true, filter });
+  return true;
+}
+
+function copyFile(rel, { skipIfExists = false } = {}) {
+  const src = path.join(tmp, rel);
+  const dest = path.join(projectRoot, rel);
+  if (!fs.existsSync(src)) return false;
+  if (skipIfExists && fs.existsSync(dest)) return false;
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
   return true;
 }
 
@@ -62,47 +72,26 @@ if (clone.status !== 0) {
 const results = [];
 const sync = (label, fn) => results.push([label, fn()]);
 
+// .github/（samples は除外）
 const githubSrc = path.join(tmp, ".github");
-sync(`.github/ ${withSamples ? "（samples 含む）" : "（samples 除外）"} / template-root 除外`, () =>
+sync(`.github/ ${withSamples ? "（samples 含む）" : "（samples 除外）"}`, () =>
   copyTree(githubSrc, path.join(projectRoot, ".github"), {
-    filter: (s) => {
-      const rel = path.relative(githubSrc, s);
-      if (TEMPLATE_ROOT_RE.test(rel)) return false;
-      if (!withSamples && SAMPLES_RE.test(rel)) return false;
-      return true;
-    },
+    filter: (s) => withSamples || !SAMPLES_RE.test(path.relative(githubSrc, s)),
   }),
 );
 
+// .claude/
 sync(".claude/", () => copyTree(path.join(tmp, ".claude"), path.join(projectRoot, ".claude")));
 
-// 共有ファイルをテーマのルートへ展開（.env.example は既存なら上書きしない）
-const keepEnvExample = (s, d) => !(path.basename(s) === ".env.example" && fs.existsSync(d));
-const templateRootSrc = path.join(tmp, ".github", "template-root");
-if (fs.existsSync(templateRootSrc)) {
-  // 新レイアウト: .github/template-root/* をまとめて展開
-  sync("template-root/* → プロジェクトルート（.env.example は既存を保持）", () =>
-    copyTree(templateRootSrc, projectRoot, { filter: keepEnvExample }),
-  );
-} else {
-  // 旧レイアウト（template-root 導入前の main）へのフォールバック: ルート直下から個別取得
-  const copyFile = (rel, { skipIfExists = false } = {}) => {
-    const src = path.join(tmp, rel);
-    const dest = path.join(projectRoot, rel);
-    if (!fs.existsSync(src)) return false;
-    if (skipIfExists && fs.existsSync(dest)) return false;
-    fs.mkdirSync(path.dirname(dest), { recursive: true });
-    fs.copyFileSync(src, dest);
-    return true;
-  };
-  sync("auth_helper.py（旧レイアウト）", () => copyFile("auth_helper.py"));
-  sync("patch-nameutils.cjs（旧レイアウト）", () => copyFile("patch-nameutils.cjs"));
-  sync("public/maps/（旧レイアウト）", () => copyTree(path.join(tmp, "public", "maps"), path.join(projectRoot, "public", "maps")));
-  sync("scripts/bootstrap.mjs（旧レイアウト）", () => copyFile(path.join("scripts", "bootstrap.mjs")));
-  sync("scripts/pre-deploy-check.mjs（旧レイアウト）", () => copyFile(path.join("scripts", "pre-deploy-check.mjs")));
-  sync(".env.example（旧レイアウト・なければ）", () => copyFile(".env.example", { skipIfExists: true }));
-}
+// 共有ファイル（標準リポと同じ相対パスにコピー）
+sync("auth_helper.py", () => copyFile("auth_helper.py"));
+sync("patch-nameutils.cjs", () => copyFile("patch-nameutils.cjs"));
+sync("public/maps/", () => copyTree(path.join(tmp, "public", "maps"), path.join(projectRoot, "public", "maps")));
+sync("scripts/bootstrap.mjs", () => copyFile(path.join("scripts", "bootstrap.mjs")));
+sync("scripts/pre-deploy-check.mjs", () => copyFile(path.join("scripts", "pre-deploy-check.mjs")));
+sync(".env.example（なければ）", () => copyFile(".env.example", { skipIfExists: true }));
 
+// spec-to-markdown の入力ディレクトリ（空で作成）
 sync("work/input/", () => {
   fs.mkdirSync(path.join(projectRoot, "work", "input"), { recursive: true });
   return true;

--- a/scripts/sync-standards.mjs
+++ b/scripts/sync-standards.mjs
@@ -10,13 +10,12 @@
  *   node scripts/sync-standards.mjs --with-samples  # サンプル実装（skills/＊/samples/）も取得
  *
  * 同期対象（標準リポ → このプロジェクト）:
- *   .github/   … エージェント・スキル（samples/ はデフォルト除外）
- *   .claude/   … Claude Code エージェント定義（存在する場合）
- *   auth_helper.py / patch-nameutils.cjs … スキルが参照する共有ヘルパー
- *   public/maps/ … japan-map スキルの共有 SVG アセット
- *   scripts/bootstrap.mjs / scripts/pre-deploy-check.mjs … 標準スクリプト
- *   work/input/ … spec-to-markdown の入力ディレクトリ（空で作成）
- *   .env.example … 存在しない場合のみコピー
+ *   .github/                  … エージェント・スキル（template-root/ と samples/ は除外）
+ *   .claude/                  … Claude Code エージェント定義（存在する場合）
+ *   .github/template-root/*   … テーマのルートに展開される共有ファイル:
+ *                                 auth_helper.py / patch-nameutils.cjs / .env.example /
+ *                                 public/maps/ / scripts/（bootstrap.mjs・pre-deploy-check.mjs）
+ *   work/input/               … spec-to-markdown の入力ディレクトリ（空で作成）
  *
  * 同期 *しない* もの:
  *   skills/＊/samples/（--with-samples 指定時を除く）
@@ -39,22 +38,12 @@ const runSetup = process.argv.includes("--setup");
 
 // skills/<name>/samples/ 配下を判定（--with-samples 指定がなければ除外）
 const SAMPLES_RE = /(^|[\\/])skills[\\/][^\\/]+[\\/]samples([\\/]|$)/;
+// .github 直下の template-root（テーマのルートへ別途展開するため .github コピーからは除外）
+const TEMPLATE_ROOT_RE = /(^|[\\/])template-root([\\/]|$)/;
 
-function copyTree(src, dest, { excludeSamples = false } = {}) {
+function copyTree(src, dest, { filter } = {}) {
   if (!fs.existsSync(src)) return false;
-  fs.cpSync(src, dest, {
-    recursive: true,
-    force: true,
-    filter: (s) => !(excludeSamples && SAMPLES_RE.test(path.relative(src, s))),
-  });
-  return true;
-}
-
-function copyFile(src, dest, { skipIfExists = false } = {}) {
-  if (!fs.existsSync(src)) return false;
-  if (skipIfExists && fs.existsSync(dest)) return false;
-  fs.mkdirSync(path.dirname(dest), { recursive: true });
-  fs.copyFileSync(src, dest);
+  fs.cpSync(src, dest, { recursive: true, force: true, filter });
   return true;
 }
 
@@ -73,18 +62,47 @@ if (clone.status !== 0) {
 const results = [];
 const sync = (label, fn) => results.push([label, fn()]);
 
-sync(`.github/ ${withSamples ? "（samples 含む）" : "（samples 除外）"}`, () =>
-  copyTree(path.join(tmp, ".github"), path.join(projectRoot, ".github"), {
-    excludeSamples: !withSamples,
+const githubSrc = path.join(tmp, ".github");
+sync(`.github/ ${withSamples ? "（samples 含む）" : "（samples 除外）"} / template-root 除外`, () =>
+  copyTree(githubSrc, path.join(projectRoot, ".github"), {
+    filter: (s) => {
+      const rel = path.relative(githubSrc, s);
+      if (TEMPLATE_ROOT_RE.test(rel)) return false;
+      if (!withSamples && SAMPLES_RE.test(rel)) return false;
+      return true;
+    },
   }),
 );
+
 sync(".claude/", () => copyTree(path.join(tmp, ".claude"), path.join(projectRoot, ".claude")));
-sync("auth_helper.py", () => copyFile(path.join(tmp, "auth_helper.py"), path.join(projectRoot, "auth_helper.py")));
-sync("patch-nameutils.cjs", () => copyFile(path.join(tmp, "patch-nameutils.cjs"), path.join(projectRoot, "patch-nameutils.cjs")));
-sync("public/maps/", () => copyTree(path.join(tmp, "public", "maps"), path.join(projectRoot, "public", "maps")));
-sync("scripts/bootstrap.mjs", () => copyFile(path.join(tmp, "scripts", "bootstrap.mjs"), path.join(projectRoot, "scripts", "bootstrap.mjs")));
-sync("scripts/pre-deploy-check.mjs", () => copyFile(path.join(tmp, "scripts", "pre-deploy-check.mjs"), path.join(projectRoot, "scripts", "pre-deploy-check.mjs")));
-sync(".env.example（なければ）", () => copyFile(path.join(tmp, ".env.example"), path.join(projectRoot, ".env.example"), { skipIfExists: true }));
+
+// 共有ファイルをテーマのルートへ展開（.env.example は既存なら上書きしない）
+const keepEnvExample = (s, d) => !(path.basename(s) === ".env.example" && fs.existsSync(d));
+const templateRootSrc = path.join(tmp, ".github", "template-root");
+if (fs.existsSync(templateRootSrc)) {
+  // 新レイアウト: .github/template-root/* をまとめて展開
+  sync("template-root/* → プロジェクトルート（.env.example は既存を保持）", () =>
+    copyTree(templateRootSrc, projectRoot, { filter: keepEnvExample }),
+  );
+} else {
+  // 旧レイアウト（template-root 導入前の main）へのフォールバック: ルート直下から個別取得
+  const copyFile = (rel, { skipIfExists = false } = {}) => {
+    const src = path.join(tmp, rel);
+    const dest = path.join(projectRoot, rel);
+    if (!fs.existsSync(src)) return false;
+    if (skipIfExists && fs.existsSync(dest)) return false;
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+    return true;
+  };
+  sync("auth_helper.py（旧レイアウト）", () => copyFile("auth_helper.py"));
+  sync("patch-nameutils.cjs（旧レイアウト）", () => copyFile("patch-nameutils.cjs"));
+  sync("public/maps/（旧レイアウト）", () => copyTree(path.join(tmp, "public", "maps"), path.join(projectRoot, "public", "maps")));
+  sync("scripts/bootstrap.mjs（旧レイアウト）", () => copyFile(path.join("scripts", "bootstrap.mjs")));
+  sync("scripts/pre-deploy-check.mjs（旧レイアウト）", () => copyFile(path.join("scripts", "pre-deploy-check.mjs")));
+  sync(".env.example（旧レイアウト・なければ）", () => copyFile(".env.example", { skipIfExists: true }));
+}
+
 sync("work/input/", () => {
   fs.mkdirSync(path.join(projectRoot, "work", "input"), { recursive: true });
   return true;

--- a/scripts/sync-standards.mjs
+++ b/scripts/sync-standards.mjs
@@ -1,0 +1,116 @@
+/**
+ * sync-standards.mjs — 開発標準（CodeAppsDevelopmentStandard）をこのプロジェクトに同期する
+ *
+ * CodeAppsDevelopmentStandard を shallow clone し、エージェント・スキル・共有ファイルを
+ * このプロジェクトにコピーする。テーマ固有のコード（src/ 等）には一切触れない。
+ *
+ * Usage:
+ *   node scripts/sync-standards.mjs                 # 標準を同期
+ *   node scripts/sync-standards.mjs --setup         # 同期後に bootstrap（環境チェック）も実行
+ *   node scripts/sync-standards.mjs --with-samples  # サンプル実装（skills/＊/samples/）も取得
+ *
+ * 同期対象（標準リポ → このプロジェクト）:
+ *   .github/   … エージェント・スキル（samples/ はデフォルト除外）
+ *   .claude/   … Claude Code エージェント定義（存在する場合）
+ *   auth_helper.py / patch-nameutils.cjs … スキルが参照する共有ヘルパー
+ *   public/maps/ … japan-map スキルの共有 SVG アセット
+ *   scripts/bootstrap.mjs / scripts/pre-deploy-check.mjs … 標準スクリプト
+ *   work/input/ … spec-to-markdown の入力ディレクトリ（空で作成）
+ *   .env.example … 存在しない場合のみコピー
+ *
+ * 同期 *しない* もの:
+ *   skills/＊/samples/（--with-samples 指定時を除く）
+ *   .power/ / src/generated/ / power.config.json … pac code init / add-data-source で SDK が生成する
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const STANDARD_REPO =
+  process.env.CODEAPPS_STANDARD_REPO ||
+  "https://github.com/geekfujiwara/CodeAppsDevelopmentStandard.git";
+
+const __filename = fileURLToPath(import.meta.url);
+const projectRoot = path.resolve(path.dirname(__filename), "..");
+const withSamples = process.argv.includes("--with-samples");
+const runSetup = process.argv.includes("--setup");
+
+// skills/<name>/samples/ 配下を判定（--with-samples 指定がなければ除外）
+const SAMPLES_RE = /(^|[\\/])skills[\\/][^\\/]+[\\/]samples([\\/]|$)/;
+
+function copyTree(src, dest, { excludeSamples = false } = {}) {
+  if (!fs.existsSync(src)) return false;
+  fs.cpSync(src, dest, {
+    recursive: true,
+    force: true,
+    filter: (s) => !(excludeSamples && SAMPLES_RE.test(path.relative(src, s))),
+  });
+  return true;
+}
+
+function copyFile(src, dest, { skipIfExists = false } = {}) {
+  if (!fs.existsSync(src)) return false;
+  if (skipIfExists && fs.existsSync(dest)) return false;
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+  return true;
+}
+
+// ── 1. 標準リポを shallow clone ──────────────────────
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sync-standards-"));
+console.log(`開発標準を取得: ${STANDARD_REPO}`);
+const clone = spawnSync("git", ["clone", "--depth", "1", STANDARD_REPO, tmp], {
+  stdio: ["ignore", "inherit", "inherit"],
+});
+if (clone.status !== 0) {
+  console.error("clone に失敗しました。ネットワークとリポジトリ URL を確認してください。");
+  process.exit(1);
+}
+
+// ── 2. 同期 ──────────────────────────────────────────
+const results = [];
+const sync = (label, fn) => results.push([label, fn()]);
+
+sync(`.github/ ${withSamples ? "（samples 含む）" : "（samples 除外）"}`, () =>
+  copyTree(path.join(tmp, ".github"), path.join(projectRoot, ".github"), {
+    excludeSamples: !withSamples,
+  }),
+);
+sync(".claude/", () => copyTree(path.join(tmp, ".claude"), path.join(projectRoot, ".claude")));
+sync("auth_helper.py", () => copyFile(path.join(tmp, "auth_helper.py"), path.join(projectRoot, "auth_helper.py")));
+sync("patch-nameutils.cjs", () => copyFile(path.join(tmp, "patch-nameutils.cjs"), path.join(projectRoot, "patch-nameutils.cjs")));
+sync("public/maps/", () => copyTree(path.join(tmp, "public", "maps"), path.join(projectRoot, "public", "maps")));
+sync("scripts/bootstrap.mjs", () => copyFile(path.join(tmp, "scripts", "bootstrap.mjs"), path.join(projectRoot, "scripts", "bootstrap.mjs")));
+sync("scripts/pre-deploy-check.mjs", () => copyFile(path.join(tmp, "scripts", "pre-deploy-check.mjs"), path.join(projectRoot, "scripts", "pre-deploy-check.mjs")));
+sync(".env.example（なければ）", () => copyFile(path.join(tmp, ".env.example"), path.join(projectRoot, ".env.example"), { skipIfExists: true }));
+sync("work/input/", () => {
+  fs.mkdirSync(path.join(projectRoot, "work", "input"), { recursive: true });
+  return true;
+});
+
+for (const [label, done] of results) {
+  console.log(`  ${done ? "✓" : "−"} ${label}${done ? "" : "（ソースに存在せずスキップ）"}`);
+}
+
+// ── 3. 後片付け ──────────────────────────────────────
+try {
+  fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 3 });
+} catch {
+  console.warn(`一時ディレクトリの削除に失敗しました（無害）: ${tmp}`);
+}
+
+console.log("開発標準の同期が完了しました。git diff で差分を確認してからコミットしてください。");
+
+// ── 4. --setup: bootstrap（環境チェック + Python venv）──
+if (runSetup) {
+  const bootstrap = path.join(projectRoot, "scripts", "bootstrap.mjs");
+  if (fs.existsSync(bootstrap)) {
+    console.log("\n環境セットアップ（bootstrap --setup）を実行します...");
+    const r = spawnSync(process.execPath, [bootstrap, "--setup"], { stdio: "inherit", cwd: projectRoot });
+    process.exit(r.status ?? 0);
+  } else {
+    console.warn("scripts/bootstrap.mjs が見つからないため環境セットアップをスキップしました。");
+  }
+}

--- a/scripts/sync-standards.mjs
+++ b/scripts/sync-standards.mjs
@@ -11,11 +11,10 @@
  *
  * 同期対象（標準リポ → このプロジェクト・同じ相対パスにコピー）:
  *   .github/             … エージェント・スキル（samples/ は除外）
+ *                          ※ auth_helper.py / patch-nameutils.cjs / 地図 SVG など
+ *                            「スキル所有アセット」は .github/skills/ 配下にあるため自動的に同期される
  *   .claude/             … Claude Code エージェント定義（存在する場合）
- *   auth_helper.py       … MSAL 認証ヘルパー
- *   patch-nameutils.cjs  … 日本語 DisplayName パッチ
- *   public/maps/         … japan-map 共有 SVG
- *   scripts/bootstrap.mjs / scripts/pre-deploy-check.mjs … 標準スクリプト
+ *   scripts/bootstrap.mjs / scripts/pre-deploy-check.mjs … プロジェクト共通ツール
  *   .env.example         … 環境変数テンプレート（既存なら上書きしない）
  *   work/input/          … spec-to-markdown の入力ディレクトリ（空で作成）
  *
@@ -83,10 +82,8 @@ sync(`.github/ ${withSamples ? "（samples 含む）" : "（samples 除外）"}`
 // .claude/
 sync(".claude/", () => copyTree(path.join(tmp, ".claude"), path.join(projectRoot, ".claude")));
 
-// 共有ファイル（標準リポと同じ相対パスにコピー）
-sync("auth_helper.py", () => copyFile("auth_helper.py"));
-sync("patch-nameutils.cjs", () => copyFile("patch-nameutils.cjs"));
-sync("public/maps/", () => copyTree(path.join(tmp, "public", "maps"), path.join(projectRoot, "public", "maps")));
+// プロジェクト共通ツール・環境テンプレート（標準リポと同じ相対パスにコピー）
+// ※ auth_helper.py / patch-nameutils.cjs / 地図 SVG は .github/ 配下にあるため上の .github 同期で配布済み
 sync("scripts/bootstrap.mjs", () => copyFile(path.join("scripts", "bootstrap.mjs")));
 sync("scripts/pre-deploy-check.mjs", () => copyFile(path.join("scripts", "pre-deploy-check.mjs")));
 sync(".env.example（なければ）", () => copyFile(".env.example", { skipIfExists: true }));


### PR DESCRIPTION
## 概要

新規テーマ開発を「CodeAppsDevelopmentStandard の直 clone」から「**CodeAppsStarter テンプレートから生成 + 開発標準を同期**」方式に移行します。前テーマ（Geek Sales 等）のデザイン・データソース接続が新テーマに残骸として混入する問題の、Starter 側の対応です。

標準リポ側の対応: geekfujiwara/CodeAppsDevelopmentStandard#173

## 新しい開始フロー

```bash
gh repo create <account>/<theme-repo> --template geekfujiwara/CodeAppsStarter --private --clone
npm install
npm run setup          # 標準（.github/ のエージェント・スキル + 共有ファイル）を同期 + 環境チェック
npm run sync-standards # 以後、標準の更新を取り込むときに再実行
```

## 追加内容

### `scripts/sync-standards.mjs`

- 標準リポを shallow clone し、許可リストのみコピー: `.github/`・`.claude/`・`auth_helper.py`・`patch-nameutils.cjs`・`public/maps/`・`scripts/bootstrap.mjs`・`scripts/pre-deploy-check.mjs`・`.env.example`（なければ）・`work/input/`
- **`skills/*/samples/` はデフォルト除外**（`--with-samples` で取得可）— サンプル実装の残骸が新テーマに混入しない
- **`.power/` / `src/generated/` / `power.config.json` は同期対象外** — `pac code init` / `pac code add-data-source` で Power Apps SDK に生成させる
- テーマ固有のコード（`src/` 等）には一切触れない
- `CODEAPPS_STANDARD_REPO` 環境変数でフォーク/ローカルパスに切替可

### 検証済み

Starter のコピーに対して、標準リポの再構成ブランチ（#173 相当）をソースに実行:
- `.github/` のエージェント・スキル一式が同期され、`samples/`（geek-sales / portal）は除外
- `templates/corporate-lp`（雛形として使うもの）は同期される
- `--with-samples` で samples も取得できる
- 共有ファイル（auth_helper.py / public/maps 等）が配置される

### その他

- `package.json` に `setup` / `sync-standards` スクリプトを追加
- README のインストール手順を Template 方式に更新

## マージ後の作業

リポジトリ設定で **Template repository** を有効化してください（このPR とあわせて実施します）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)